### PR TITLE
feat: Separate S3 dependencies to an optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,16 @@ embeddings.pooled
 
 ### Exporting the Model
 
-Once you are done testing and training the model, it can be exported into a single tarball that can be uploaded to S3 using:
+Once you are done testing and training the model, it can be exported into a single tarball:
+
+```python
+from transformer_embeddings import TransformerEmbeddings
+
+transformer = TransformerEmbeddings("model_name")
+transformer.export(additional_files=["/path/to/other/files/to/include/in/tarball.pickle"])
+```
+
+This tarball can also be uploaded to S3, but requires installing the S3 extras (`pip install transformer-embeddings[s3]`). And then using:
 
 ```python
 from transformer_embeddings import TransformerEmbeddings

--- a/poetry.lock
+++ b/poetry.lock
@@ -5,7 +5,7 @@ name = "aiobotocore"
 version = "2.4.2"
 description = "Async client for aws services using botocore and aiohttp"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "aiobotocore-2.4.2-py3-none-any.whl", hash = "sha256:4acd1ebe2e44be4b100aa553910bda899f6dc090b3da2bc1cf3d5de2146ed208"},
@@ -27,7 +27,7 @@ name = "aiohttp"
 version = "3.8.4"
 description = "Async http client/server framework (asyncio)"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "aiohttp-3.8.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5ce45967538fb747370308d3145aa68a074bdecb4f3a300869590f725ced69c1"},
@@ -138,7 +138,7 @@ name = "aioitertools"
 version = "0.11.0"
 description = "itertools and builtins for AsyncIO and mixed iterables"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "aioitertools-0.11.0-py3-none-any.whl", hash = "sha256:04b95e3dab25b449def24d7df809411c10e62aab0cbe31a50ca4e68748c43394"},
@@ -153,7 +153,7 @@ name = "aiosignal"
 version = "1.3.1"
 description = "aiosignal: a list of registered asynchronous callbacks"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
@@ -186,7 +186,7 @@ name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
@@ -201,7 +201,7 @@ name = "asynctest"
 version = "0.13.0"
 description = "Enhance the standard unittest package with features for testing asyncio libraries"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 files = [
     {file = "asynctest-0.13.0-py3-none-any.whl", hash = "sha256:5da6118a7e6d6b54d83a8f7197769d046922a44d2a99c21382f0a6e4fadae676"},
@@ -251,7 +251,7 @@ name = "botocore"
 version = "1.27.59"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
-optional = false
+optional = true
 python-versions = ">= 3.7"
 files = [
     {file = "botocore-1.27.59-py3-none-any.whl", hash = "sha256:69d756791fc024bda54f6c53f71ae34e695ee41bbbc1743d9179c4837a4929da"},
@@ -644,7 +644,7 @@ name = "frozenlist"
 version = "1.3.3"
 description = "A list-like structure which implements collections.abc.MutableSequence"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "frozenlist-1.3.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ff8bf625fe85e119553b5383ba0fb6aa3d0ec2ae980295aaefa552374926b3f4"},
@@ -728,7 +728,7 @@ name = "fsspec"
 version = "2023.1.0"
 description = "File-system specification"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "fsspec-2023.1.0-py3-none-any.whl", hash = "sha256:b833e2e541e9e8cde0ab549414187871243177feb3d344f9d27b25a93f5d8139"},
@@ -952,7 +952,7 @@ name = "jmespath"
 version = "1.0.1"
 description = "JSON Matching Expressions"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
@@ -1001,7 +1001,7 @@ name = "multidict"
 version = "6.0.4"
 description = "multidict implementation"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "multidict-6.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b1a97283e0c85772d613878028fec909f003993e1007eafa715b24b377cb9b8"},
@@ -1398,7 +1398,7 @@ name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
 category = "main"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
@@ -1697,7 +1697,7 @@ name = "s3fs"
 version = "2023.1.0"
 description = "Convenient Filesystem interface over S3"
 category = "main"
-optional = false
+optional = true
 python-versions = ">= 3.7"
 files = [
     {file = "s3fs-2023.1.0-py3-none-any.whl", hash = "sha256:a549ae518fff4388bd6fca5248575c29f521e7e39efcd2bfab476651701fd114"},
@@ -1743,14 +1743,14 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "67.3.1"
+version = "67.3.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.3.1-py3-none-any.whl", hash = "sha256:23c86b4e44432bfd8899384afc08872ec166a24f48a3f99f293b0a557e6a6b5d"},
-    {file = "setuptools-67.3.1.tar.gz", hash = "sha256:daec07fd848d80676694d6bf69c009d28910aeece68a38dbe88b7e1bb6dba12e"},
+    {file = "setuptools-67.3.2-py3-none-any.whl", hash = "sha256:bb6d8e508de562768f2027902929f8523932fcd1fb784e6d573d2cafac995a48"},
+    {file = "setuptools-67.3.2.tar.gz", hash = "sha256:95f00380ef2ffa41d9bba85d95b27689d923c93dfbafed4aecd7cf988a25e012"},
 ]
 
 [package.extras]
@@ -2094,7 +2094,7 @@ name = "wrapt"
 version = "1.14.1"
 description = "Module for decorators, wrappers and monkey patching."
 category = "main"
-optional = false
+optional = true
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 files = [
     {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
@@ -2168,7 +2168,7 @@ name = "yarl"
 version = "1.8.2"
 description = "Yet another URL library"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "yarl-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bb81f753c815f6b8e2ddd2eef3c855cf7da193b82396ac013c661aaa6cc6b0a5"},
@@ -2268,7 +2268,10 @@ files = [
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+s3 = ["s3fs"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7,<3.11"
-content-hash = "8e14621b93eaa0ce06f58c16d8302cb723bedabe05fb6d62b77a9ef38f31f244"
+content-hash = "f3542f3361a3251596623e44e95c98f4c807ba4a6be360d60734d6285a998757"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ Changelog = "https://github.com/ginger-io/transformer-embeddings/releases"
 python = "^3.7,<3.11"
 transformers = "^4.23.1"
 torch = "^1.9.1"
-s3fs = "^2023.1.0"
+s3fs = { version = "^2023.1.0", optional = true }
 
 [tool.poetry.group.test.dependencies]
 pytest = "^7.1.3"
@@ -32,6 +32,9 @@ pre-commit = "^2.20.0"
 
 [tool.poetry.group.release.dependencies]
 python-semantic-release = "^7.32.1"
+
+[tool.poetry.extras]
+s3 = ["s3fs"]
 
 [tool.isort]
 profile = "black"

--- a/src/transformer_embeddings/model.py
+++ b/src/transformer_embeddings/model.py
@@ -220,7 +220,9 @@ class TransformerEmbeddings:
         input = None
         pooled = None
         for i in trange(0, len(input_strings), self.batch_size):
-            batch_tokenized_input = self.tokenize(input_strings[i : i + self.batch_size])
+            batch_tokenized_input = self.tokenize(
+                input_strings[i : i + self.batch_size]
+            )
 
             with no_grad():
                 batch_outputs = self.model(**batch_tokenized_input.to(DEVICE))
@@ -289,7 +291,9 @@ class TransformerEmbeddings:
             try:
                 from s3fs import S3FileSystem
             except ImportError:
-                raise ImportError("Please install the s3 extras of the package to upload to S3.")
+                raise ImportError(
+                    "Please install the s3 extras of the package to upload to S3."
+                )
 
             s3_fs = S3FileSystem()
             logger.info(f"Tarball {compressed_file} being uploaded to S3 at {s3_path}.")


### PR DESCRIPTION
## Description

Here we are separating out S3 dependencies to be optional and an extra instead of a primary dependency for this package.

## Changes

- chore: Mark `s3fs` as an optional dep
- fix: Raise error if optional dependencies are missing
- docs: Add separate export and upload code examples
- style: Apply `black`

## Tests

- [x] Local.
- [x] CI.